### PR TITLE
[356] Fixed response code from 500 Internal Server to 200 OK in UserController [POST /user/deleteDeactivatedUsers]

### DIFF
--- a/dao/src/main/java/greencity/repository/UserRepo.java
+++ b/dao/src/main/java/greencity/repository/UserRepo.java
@@ -138,7 +138,7 @@ public interface UserRepo extends JpaRepository<User, Long>, JpaSpecificationExe
      * @author Vasyl Zhovnir
      **/
     @Modifying
-    @Query(nativeQuery = true, value = "DELETE FROM users where status = 1 "
+    @Query(nativeQuery = true, value = "DELETE FROM users where user_status = 1 "
         + "AND last_activity_time + interval '2 year' <= CURRENT_TIMESTAMP")
     int scheduleDeleteDeactivatedUsers();
 


### PR DESCRIPTION
[POST /user/deleteDeactivatedUsers] In POST /user/deleteDeactivatedUsers response 500 Internal Server
Environment: Firefox 116.0.3 (64-bit).
Reproducible: always.

Preconditions
Moved to Swagger http://localhost:8065/swagger-ui.html#/
Sign-in us Admin.

Steps to reproduce

Click on User controller.
Click on POST /user/deleteDeactivatedUsers.
Click on 'Try out'.
Actual result
Response 500 Internal Server.

Expected result
200 OK.