### PR TITLE
Bug fixes/291 post/user/search response 500

### DIFF
--- a/service-api/src/test/java/greencity/security/jwt/JwtToolTest.java
+++ b/service-api/src/test/java/greencity/security/jwt/JwtToolTest.java
@@ -6,9 +6,8 @@ import greencity.enums.Role;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import jakarta.servlet.http.HttpServletRequest;
-import java.util.Date;
-import java.util.List;
-import java.util.UUID;
+
+import java.util.*;
 import javax.crypto.SecretKey;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -59,12 +58,12 @@ class JwtToolTest {
         assertEquals(expectedEmail, actualEmail);
         @SuppressWarnings({"unchecked, rawtype"})
         List<String> authorities = (List<String>) Jwts.parser()
-            .verifyWith(key)
-            .build()
-            .parseSignedClaims(accessToken)
-            .getPayload()
-            .get(ROLE);
-        assertEquals(expectedRole, Role.valueOf(authorities.getFirst()));
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(accessToken)
+                .getPayload()
+                .get(ROLE);
+        assertEquals(expectedRole, Role.valueOf(authorities.get(0)));
     }
 
     @Test
@@ -85,12 +84,12 @@ class JwtToolTest {
         assertEquals(expectedEmail, actualEmail);
         @SuppressWarnings({"unchecked, rawtype"})
         List<String> authorities = (List<String>) Jwts.parser()
-            .verifyWith(key)
-            .build()
-            .parseSignedClaims(refreshToken)
-            .getPayload()
-            .get(ROLE);
-        assertEquals(expectedRole, Role.valueOf(authorities.getFirst()));
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(refreshToken)
+                .getPayload()
+                .get(ROLE);
+        assertEquals(expectedRole, Role.valueOf(authorities.get(0)));
     }
 
     @Test

--- a/service/src/main/java/greencity/filters/CustomSpecification.java
+++ b/service/src/main/java/greencity/filters/CustomSpecification.java
@@ -36,7 +36,7 @@ public interface CustomSpecification<T> extends Specification<T> {
     default Predicate getEnumPredicate(Root<T> root, CriteriaBuilder criteriaBuilder,
         SearchCriteria searchCriteria) {
         return searchCriteria.getValue().toString().trim().equals("") ? criteriaBuilder.conjunction()
-            : criteriaBuilder.equal(root.get(searchCriteria.getKey()).as(Integer.class),
+            : criteriaBuilder.equal(root.get(searchCriteria.getKey()).as(String.class),
                 searchCriteria.getValue());
     }
 }

--- a/service/src/test/java/greencity/filters/CustomSpecificationTest.java
+++ b/service/src/test/java/greencity/filters/CustomSpecificationTest.java
@@ -26,7 +26,7 @@ class CustomSpecificationTest {
     @Mock
     private Path<Object> objectPathExpected;
     @Mock
-    private Expression<Integer> as;
+    private Expression<String> as;
     List<SearchCriteria> searchCriteriaList;
     UserSpecification userSpecification;
 
@@ -100,7 +100,7 @@ class CustomSpecificationTest {
     void getEnumPredicate() {
         when(criteriaBuilder.conjunction()).thenReturn(expected);
         when(root.get(searchCriteriaList.get(5).getKey())).thenReturn(objectPathExpected);
-        when(objectPathExpected.as(Integer.class)).thenReturn(as);
+        when(objectPathExpected.as(String.class)).thenReturn(as);
         when(criteriaBuilder.equal(as, searchCriteriaList.get(5).getValue())).thenReturn(expected);
         Predicate actual = userSpecification.getEnumPredicate(root, criteriaBuilder, searchCriteriaList.get(5));
         assertEquals(expected, actual);

--- a/service/src/test/java/greencity/filters/UserSpecificationTest.java
+++ b/service/src/test/java/greencity/filters/UserSpecificationTest.java
@@ -2,6 +2,7 @@ package greencity.filters;
 
 import greencity.dto.user.UserManagementViewDto;
 import greencity.entity.User;
+import greencity.enums.Role;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -29,7 +30,8 @@ class UserSpecificationTest {
     @Mock
     private Path<Object> objectPathExpected;
     @Mock
-    private Expression<Integer> as;
+    private Expression<String> as;
+
     List<SearchCriteria> searchCriteriaList;
     UserSpecification userSpecification;
 
@@ -42,7 +44,7 @@ class UserSpecificationTest {
             .name("test")
             .email("test@ukr.net")
             .userCredo("test")
-            .role("1")
+            .role(Role.ROLE_USER.name())
             .userStatus("2")
             .build();
         searchCriteriaList.add(SearchCriteria.builder()
@@ -100,12 +102,11 @@ class UserSpecificationTest {
         when(criteriaBuilder.and(expected, expected)).thenReturn(expected);
         when(criteriaBuilder.conjunction()).thenReturn(expected);
         when(root.get(searchCriteriaList.get(4).getKey())).thenReturn(objectPathExpected);
-        when(objectPathExpected.as(Integer.class)).thenReturn(as);
+        when(objectPathExpected.as(String.class)).thenReturn(as);
         when(criteriaBuilder.equal(as, searchCriteriaList.get(4).getValue())).thenReturn(expected);
         when(criteriaBuilder.and(expected, expected)).thenReturn(expected);
         when(criteriaBuilder.conjunction()).thenReturn(expected);
         when(root.get(searchCriteriaList.get(5).getKey())).thenReturn(objectPathExpected);
-        when(objectPathExpected.as(Integer.class)).thenReturn(as);
         when(criteriaBuilder.equal(as, searchCriteriaList.get(5).getValue())).thenReturn(expected);
         when(criteriaBuilder.and(expected, expected)).thenReturn(expected);
         Predicate actual = userSpecification.toPredicate(root, criteriaQuery, criteriaBuilder);


### PR DESCRIPTION
[[291](https://github.com/users/OlhenShu/projects/10/views/1?pane=issue&itemId=55308678)] fixed a bug in the CustomSpecification method getEnumPredicate where it was using enum indexes instead of values, that caused issues when tried to get data from the User table where role column contains names, not indexes.

Additionally, refactored tests in CustomSpecification and UserSpecification test classes.